### PR TITLE
Fix koddsson.cooking URL

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ A software engineer with a penchant for working with Web Platform features and h
   <a href="https://x.com/koddsson">Twitter</a>
   <a href="https://read.cv/koddsson">ReadCV</a>
   <a href="https://linkedin.com/in/koddsson">LinkedIn</a>
-  <a href="https://koddsson.cooking">koddsson.cooking</a>
+  <a href="https://github.com/koddsson/cooking">koddsson.cooking</a>
 </nav>
 
 ## Posts


### PR DESCRIPTION
https://koddsson.cooking/ was supposed to redirect to https://github.com/koddsson/cooking, but `https` isn't working, only `http`. So here I change it to the repo directly instead of changing it to an unsafe protocol link.

also your link contrast is quite low?

<img width="747" alt="" src="https://github.com/user-attachments/assets/ffb703b3-ea81-4367-9e2b-2e8255c7cae7">
