### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -18,6 +18,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   process:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/koddsson/koddsson.com/security/code-scanning/18](https://github.com/koddsson/koddsson.com/security/code-scanning/18)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Specifically:
- `contents: write` is required for the `git push` step.
- Other permissions will default to `none` unless explicitly required.

The `permissions` block will be added at the top level of the workflow, applying to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
