### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push, workflow_dispatch]
+permissions:
+  contents: write
 jobs:
   lhci:
     name: Lighthouse


### PR DESCRIPTION
Potential fix for [https://github.com/koddsson/koddsson.com/security/code-scanning/17](https://github.com/koddsson/koddsson.com/security/code-scanning/17)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required for the workflow. Based on the steps in the workflow:
- The `actions/checkout@v4` and `peaceiris/actions-gh-pages@v4` steps require `contents: read` and `contents: write`, respectively.
- The `LHCI_GITHUB_APP_TOKEN` is used for Lighthouse CI, but it does not require additional permissions for the `GITHUB_TOKEN`.
- No other steps require additional permissions.

We will set the root-level `permissions` block to:
```yaml
permissions:
  contents: write
```
This ensures that the workflow has the necessary permissions for the `Deploy` step while adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
