### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/speedify.yml
+++ b/.github/workflows/speedify.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "00 */23 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/koddsson/koddsson.com/security/code-scanning/16](https://github.com/koddsson/koddsson.com/security/code-scanning/16)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only triggers an external Netlify build and does not interact with the repository or other GitHub features, the minimal required permission is `contents: read`. This ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
