### PR TITLE
Cache-bust CSS with content-hash query strings

### DIFF
--- a/_data/assets.js
+++ b/_data/assets.js
@@ -1,0 +1,22 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import crypto from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function hash(relativePath) {
+  const contents = await fs.readFile(
+    path.join(__dirname, "..", relativePath),
+  );
+  return crypto.createHash("sha256").update(contents).digest("hex").slice(0, 8);
+}
+
+export default async function () {
+  const [index, prism] = await Promise.all([
+    hash("css/index.css"),
+    hash("css/prism-vs.css"),
+  ]);
+  return { css: { index, prism } };
+}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,8 +19,8 @@
     <title>{{ title }}</title>
     <meta property="og:title" content="{{ title }}" />
 
-    <link rel="stylesheet" href="/css/prism-vs.css">
-    <link rel="stylesheet" href="/css/index.css">
+    <link rel="stylesheet" href="/css/prism-vs.css?v={{ assets.css.prism }}">
+    <link rel="stylesheet" href="/css/index.css?v={{ assets.css.index }}">
 
     <script type="importmap">
       {


### PR DESCRIPTION
## Summary
- Cloudflare's edge cache held the old `/css/index.css` for up to a year (`max-age=31536000`), so the brutalist-redesign deploy left visitors on the pre-redesign CSS until the cache was manually purged.
- Adds a tiny `_data/assets.js` that hashes the source CSS files at build time, and updates `_layouts/default.html` to append `?v=<hash>` to each `<link>`. When the CSS source changes, the URL changes, and Cloudflare misses the edge cache.
- No filename rename, no plugin changes — just two stylesheet `<link>` tags.

## Test plan
- [x] `npm run build` produces `<link rel="stylesheet" href="/css/index.css?v=146419e9">` (and same hash for prism)
- [x] Hashes are consistent across pages (homepage, posts/, notes/, 404)
- [ ] After merge: confirm production HTML references the new query string

🤖 Generated with [Claude Code](https://claude.com/claude-code)