### PR TITLE
Add /now page

### DIFF
--- a/_data/latestRun.js
+++ b/_data/latestRun.js
@@ -1,0 +1,111 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import workouts from "./workouts.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function formatHMS(seconds) {
+  const total = Math.round(seconds || 0);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (n) => String(n).padStart(2, "0");
+  if (h > 0) return `${h}:${pad(m)}:${pad(s)}`;
+  return `${m}:${pad(s)}`;
+}
+
+function paceFromSpeed(speed) {
+  if (!speed) return null;
+  const secPerKm = 1000 / speed;
+  const m = Math.floor(secPerKm / 60);
+  const s = Math.round(secPerKm % 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function relativeDate(iso, now = new Date()) {
+  if (!iso) return null;
+  const then = new Date(iso);
+  const diffDays = Math.floor((now - then) / 86400000);
+  if (diffDays < 1) return "TODAY";
+  if (diffDays === 1) return "1D AGO";
+  if (diffDays < 7) return `${diffDays}D AGO`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)}W AGO`;
+  return `${Math.floor(diffDays / 30)}MO AGO`;
+}
+
+function parsePlan(description) {
+  if (!description) return null;
+  const m = description.match(/(?:wk|week)\s*(\d+)\s*(?:of|\/)\s*(\d+)/i);
+  if (!m) return null;
+  return `WK ${m[1]}/${m[2]}`;
+}
+
+function fitRouteSvg(svgContent) {
+  if (!svgContent) return null;
+  const pathMatch = svgContent.match(/<path[^>]*\sd="([^"]+)"/);
+  if (!pathMatch) return svgContent;
+  const d = pathMatch[1];
+
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  const re = /(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)/g;
+  let m;
+  while ((m = re.exec(d)) !== null) {
+    const x = parseFloat(m[1]);
+    const y = parseFloat(m[2]);
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+  }
+  if (!isFinite(minX)) return svgContent;
+
+  const w = maxX - minX || 1;
+  const h = maxY - minY || 1;
+  const pad = Math.max(w, h) * 0.06;
+  const vb = [
+    (minX - pad).toFixed(2),
+    (minY - pad).toFixed(2),
+    (w + pad * 2).toFixed(2),
+    (h + pad * 2).toFixed(2),
+  ].join(" ");
+
+  return svgContent
+    .replace(/viewBox="[^"]*"/, `viewBox="${vb}"`)
+    .replace(/<path /, '<path pathLength="100" ');
+}
+
+async function loadRouteSvg(relPath) {
+  if (!relPath) return null;
+  try {
+    const full = path.join(__dirname, "..", relPath);
+    const raw = await fs.readFile(full, "utf-8");
+    return fitRouteSvg(raw);
+  } catch {
+    return null;
+  }
+}
+
+export default async function () {
+  const list = await workouts();
+  const item = list[0];
+  if (!item) return null;
+  const a = item.data?.activity;
+  if (!a) return null;
+  const routeSvg = await loadRouteSvg(item.svgPath);
+  return {
+    name: a.name,
+    distanceKm: ((a.distance || 0) / 1000).toFixed(2),
+    movingTime: formatHMS(a.moving_time),
+    pacePerKm: paceFromSpeed(a.average_speed),
+    elevGain: Math.round(a.total_elevation_gain || 0),
+    startDate: a.start_date,
+    ago: relativeDate(a.start_date),
+    svgPath: item.svgPath,
+    routeSvg,
+    device: a.device_name,
+    plan: parsePlan(a.description),
+    activityId: a.id,
+  };
+}

--- a/_data/now.json
+++ b/_data/now.json
@@ -1,0 +1,3 @@
+{
+  "feeds": ["strava", "goodreads"]
+}

--- a/_data/reading.js
+++ b/_data/reading.js
@@ -1,0 +1,33 @@
+import EleventyFetch from "@11ty/eleventy-fetch";
+
+const ENDPOINT = "https://atlas.koddsson.deno.net/goodreads";
+
+function isoDate(value) {
+  if (!value) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().slice(0, 10);
+}
+
+export default async function () {
+  let data;
+  try {
+    data = await EleventyFetch(ENDPOINT, {
+      duration: "1h",
+      type: "json",
+    });
+  } catch (err) {
+    console.warn(`[reading] Atlas fetch failed: ${err.message}`);
+    return null;
+  }
+
+  const item = data?.currently_reading?.[0];
+  if (!item?.book) return null;
+
+  return {
+    title: item.book,
+    pct: typeof item.percent === "number" ? item.percent : null,
+    startedAt: isoDate(item.started_at),
+    updatedAt: isoDate(item.updated_at),
+  };
+}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -65,6 +65,7 @@
         <a href="/images/"{% if url contains '/images/' %} class="active"{% endif %}>IMAGES</a>
         <a href="/workouts/"{% if url contains '/workouts/' %} class="active"{% endif %}>WORKOUTS</a>
         <a href="/reading-list/"{% if url contains '/reading-list/' %} class="active"{% endif %}>READING</a>
+        <a href="/now/"{% if url contains '/now/' %} class="active"{% endif %}>NOW</a>
       </nav>
       <span class="masthead-meta">
         <a class="rss-link" href="/feed.xml">RSS↗</a>

--- a/css/index.css
+++ b/css/index.css
@@ -972,6 +972,195 @@ main figure figcaption {
 /* ── Toot embed ────────────────────────────────────────── */
 toot-embed { display: block; margin: 16px 0; }
 
+/* ── /now page ─────────────────────────────────────────── */
+.now-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 40px;
+}
+
+.now-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(56px, 11vw, 90px);
+  line-height: 0.88;
+  letter-spacing: -0.045em;
+  text-transform: uppercase;
+  margin: 16px 0 12px;
+  overflow-wrap: break-word;
+}
+
+.now-title .accent { color: var(--accent); }
+
+.now-asof {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink-2);
+  margin-bottom: 18px;
+}
+
+.now-lead-foot {
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+  border-top: var(--rule-1);
+  padding-top: 12px;
+  margin-top: 24px;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.now-lead-foot a {
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.now-col { display: flex; flex-direction: column; }
+
+.now-panel {
+  border-top: var(--rule-2);
+  padding: 14px 0 20px;
+}
+
+.now-panel:last-child { border-bottom: var(--rule-2); }
+
+.now-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 10px;
+}
+
+.now-head .num {
+  font-family: var(--font-mono);
+  letter-spacing: 0;
+  color: var(--ink-2);
+}
+
+.now-h2 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.now-h2 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.now-h2 a:hover { color: var(--accent); }
+
+.now-sub {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-2);
+  margin-top: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.now-route {
+  margin-top: 12px;
+  background: var(--surface);
+  border: var(--rule-1);
+  padding: 14px;
+  aspect-ratio: 16 / 9;
+}
+
+.now-route svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.now-route svg path {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 10;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 100;
+  animation: now-route-draw 6s ease-in-out infinite;
+}
+
+@keyframes now-route-draw {
+  0% { stroke-dashoffset: 100px; }
+  60%, 100% { stroke-dashoffset: 0px; }
+}
+
+.now-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin-top: 10px;
+  border: var(--rule-1);
+}
+
+.now-stats .stat {
+  padding: 8px 10px;
+  border-right: var(--rule-1);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--ink-2);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.now-stats .stat:last-child { border-right: 0; }
+
+.now-stats .stat b {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  line-height: 1;
+}
+
+.now-reading-bar { margin-top: 12px; }
+
+.now-reading-bar .bar {
+  height: 6px;
+  border: var(--rule-1);
+}
+
+.now-reading-bar .bar i {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+}
+
+.now-reading-bar .now-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-2);
+  margin-top: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .now-route svg path { animation: none; stroke-dashoffset: 0; }
+}
+
+@media (max-width: 900px) {
+  .now-grid { grid-template-columns: 1fr; gap: 32px; }
+}
+
 /* ── Syntax-highlight tweaks ───────────────────────────── */
 .token.url, .token.symbol, .token.number, .token.boolean,
 .token.variable, .token.constant, .token.inserted {

--- a/now/index.liquid
+++ b/now/index.liquid
@@ -1,0 +1,64 @@
+---
+permalink: /now/index.html
+layout: default
+title: "Now"
+description: "What I'm currently doing — latest run, current book, now playing — built from live feeds."
+noPageHeader: true
+---
+
+<section class="now-grid">
+  <div class="now-lead">
+    <h1 class="now-title">NOW.<br><span class="accent">CURRENTLY.</span></h1>
+    <div class="now-asof">
+      AS OF {{ buildDate | date: '%Y-%m-%d' }} · {{ buildDate | date: '%H:%M' }} UTC · BUILT FROM {{ now.feeds.size }} FEEDS
+    </div>
+    <div class="now-lead-foot">
+      <a href="/">← BACK TO HOME</a>
+      <a href="https://github.com/koddsson/koddsson.com">SOURCE · GITHUB/KODDSSON/KODDSSON.COM</a>
+    </div>
+  </div>
+
+  <div class="now-col">
+    {% if latestRun %}
+      <section class="now-panel">
+        <div class="now-head">
+          <span>§ 01 · LATEST RUN</span>
+          <span class="num">STRAVA{% if latestRun.ago %} · {{ latestRun.ago }}{% endif %}</span>
+        </div>
+        <h2 class="now-h2">{{ latestRun.name }}</h2>
+        {% if latestRun.device or latestRun.plan %}
+          <div class="now-sub">{% if latestRun.device %}{{ latestRun.device | upcase }}{% endif %}{% if latestRun.device and latestRun.plan %} · {% endif %}{% if latestRun.plan %}{{ latestRun.plan }}{% endif %}</div>
+        {% endif %}
+        {% if latestRun.routeSvg %}
+          <div class="now-route">{{ latestRun.routeSvg }}</div>
+        {% endif %}
+        <div class="now-stats">
+          <div class="stat"><b>{{ latestRun.distanceKm }}</b><span>KM</span></div>
+          <div class="stat"><b>{{ latestRun.pacePerKm }}</b><span>/KM PACE</span></div>
+          <div class="stat"><b>{{ latestRun.movingTime }}</b><span>MOVING</span></div>
+          <div class="stat"><b>+{{ latestRun.elevGain }}</b><span>ELEV M</span></div>
+        </div>
+      </section>
+    {% endif %}
+
+    {% if reading %}
+      <section class="now-panel">
+        <div class="now-head">
+          <span>§ 02 · READING</span>
+          <span class="num">GOODREADS{% if reading.pct %} · {{ reading.pct }}%{% endif %}</span>
+        </div>
+        <h2 class="now-h2">{{ reading.title }}</h2>
+        {% if reading.startedAt %}
+          <div class="now-sub">STARTED {{ reading.startedAt | date: '%b %-d' | upcase }}</div>
+        {% endif %}
+        {% if reading.pct %}
+          <div class="now-reading-bar">
+            <div class="bar"><i style="width: {{ reading.pct }}%"></i></div>
+            <div class="now-meta">{{ reading.pct }}% COMPLETE{% if reading.updatedAt %} · UPDATED {{ reading.updatedAt | date: '%b %-d' | upcase }}{% endif %}</div>
+          </div>
+        {% endif %}
+      </section>
+    {% endif %}
+
+  </div>
+</section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@11ty/eleventy": "^3.1.5",
+        "@11ty/eleventy-fetch": "^5.1.2",
         "@11ty/eleventy-img": "^6.0.4",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
         "@jgarber/eleventy-plugin-postcss": "^3.0.1",
@@ -188,16 +189,16 @@
       }
     },
     "node_modules/@11ty/eleventy-fetch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-fetch/-/eleventy-fetch-5.1.0.tgz",
-      "integrity": "sha512-gSmCA3olJxRwtTkXyS+KIanq1kEufCC+JsHyTa7ta5NqmeUQlWA8zEngtXrDl+ebrAvFz2bNaxLd+0ERpnnSPQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-fetch/-/eleventy-fetch-5.1.2.tgz",
+      "integrity": "sha512-YxDARdR3S9UT4gOGRWgGNyokYT9jkCAjJge3OVKFdNMv1cyvWg1NHCvj9NVvK9XHenCLFy3cwvM/YYpZZTZopw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@11ty/eleventy-utils": "^2.0.7",
         "@rgrove/parse-xml": "^4.2.0",
-        "debug": "^4.4.0",
-        "flatted": "^3.3.3",
+        "debug": "^4.4.3",
+        "flatted": "^3.4.2",
         "p-queue": "6.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "devDependencies": {
     "@11ty/eleventy": "^3.1.5",
+    "@11ty/eleventy-fetch": "^5.1.2",
     "@11ty/eleventy-img": "^6.0.4",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
     "@jgarber/eleventy-plugin-postcss": "^3.0.1",


### PR DESCRIPTION
## Summary
- New `/now/` route inspired by [nownownow.com](https://nownownow.com): a brutalist status page surfacing what I'm currently up to.
- **Latest run** panel — pulls the most recent Strava activity from existing `_data/workouts/*.json`, with an animated route trace (viewBox auto-fitted to the path bounding box, `pathLength="100"` normalized so the CSS draw animation works regardless of the route's real length) and KM / pace / moving-time / elev stats.
- **Reading** panel — fetches my currently-reading book from `atlas.koddsson.deno.net/goodreads` (Goodreads aggregator), with a real progress bar (% complete) and start date. Cached via `@11ty/eleventy-fetch` (1h TTL).
- Reuses existing design tokens in `css/index.css` (`--ink`, `--accent`, `--rule-*`, fonts). New selectors namespaced `.now-*`. `prefers-reduced-motion` respected.
- `NOW` added to the masthead nav with the existing `.active` styling.
- Listening panel intentionally deferred until Last.fm is wired the same way.

## Test plan
- [ ] `npm run build` succeeds without warnings
- [ ] `/now/` renders hero (NOW. / CURRENTLY.), latest run panel with route + stats, reading panel with progress bar
- [ ] `NOW` nav item highlights when on `/now/`
- [ ] Route trace animates; stops with `prefers-reduced-motion: reduce`
- [ ] Mobile (<900px) collapses to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)