### PR TITLE
Fix syndication URL slugs and surface platform errors

### DIFF
--- a/posts/2026-05-13-how-to-mitm-your-own-phone-for-fun-and-profit.md
+++ b/posts/2026-05-13-how-to-mitm-your-own-phone-for-fun-and-profit.md
@@ -5,8 +5,6 @@ layout: default.html
 date: 2026-05-13T00:00:00.000Z
 description: I recently found out how to sniff network requests from apps using `mitmproxy`
 syndicate: true
-syndicated_to:
-  bluesky: 'https://bsky.app/profile/koddsson.com/post/3mlpxs3vvd72q'
 ---
 
 I recently discovered that you are able to use a combination of the [WireGuard](https://www.wireguard.com/) vpn app on your iPhone and [`mitmproxy`](https://www.mitmproxy.org/) on your macOS to listen to network requests that your phone is making to the wider network.

--- a/scripts/syndicate.js
+++ b/scripts/syndicate.js
@@ -9,6 +9,8 @@ const SITE_URL = "https://koddsson.com";
 
 const DRY_RUN = process.argv.includes("--dry-run");
 
+const errors = [];
+
 // Character limits
 const MASTODON_LIMIT = 500;
 const BLUESKY_LIMIT = 300;
@@ -34,7 +36,8 @@ function findSyndicatable() {
       const { data, content } = matter(raw);
 
       if (!data.syndicate) continue;
-      if (data.syndicated_to && Object.keys(data.syndicated_to).length > 0) continue;
+      const syndicated = data.syndicated_to || {};
+      if (syndicated.mastodon && syndicated.bluesky) continue;
 
       files.push({ filePath, data, content: content.trim(), dir });
     }
@@ -43,7 +46,11 @@ function findSyndicatable() {
 }
 
 function buildCanonicalUrl(dir, filePath) {
-  const slug = path.basename(filePath, ".md");
+  const basename = path.basename(filePath, ".md");
+  // Mirror Eleventy's `page.fileSlug`: strip a leading YYYY-MM-DD- date prefix,
+  // but keep filenames that are *only* a date (e.g. notes/2026-03-06.md).
+  const match = basename.match(/^\d{4}-\d{2}-\d{2}-(.+)$/);
+  const slug = match ? match[1] : basename;
   return `${SITE_URL}/${dir}/${slug}/`;
 }
 
@@ -279,23 +286,34 @@ async function syndicateMarkdownPosts(blueskySession) {
       continue;
     }
 
-    const syndicated_to = {};
+    const existing = data.syndicated_to || {};
+    const syndicated_to = { ...existing };
 
-    try {
-      const mastodonUrl = await postToMastodon(mastodonText);
-      console.log(`Mastodon: ${mastodonUrl}`);
-      syndicated_to.mastodon = mastodonUrl;
-    } catch (err) {
-      console.error(`Mastodon error: ${err.message}`);
+    if (!syndicated_to.mastodon) {
+      try {
+        const mastodonUrl = await postToMastodon(mastodonText);
+        console.log(`Mastodon: ${mastodonUrl}`);
+        syndicated_to.mastodon = mastodonUrl;
+      } catch (err) {
+        console.error(`Mastodon error: ${err.message}`);
+        errors.push(`${path.relative(ROOT, filePath)} → Mastodon: ${err.message}`);
+      }
+    } else {
+      console.log("Mastodon: already syndicated, skipping.");
     }
 
-    try {
-      if (!blueskySession.session) blueskySession.session = await blueskyLogin();
-      const blueskyUrl = await postToBluesky(blueskyText, blueskySession.session);
-      console.log(`Bluesky: ${blueskyUrl}`);
-      syndicated_to.bluesky = blueskyUrl;
-    } catch (err) {
-      console.error(`Bluesky error: ${err.message}`);
+    if (!syndicated_to.bluesky) {
+      try {
+        if (!blueskySession.session) blueskySession.session = await blueskyLogin();
+        const blueskyUrl = await postToBluesky(blueskyText, blueskySession.session);
+        console.log(`Bluesky: ${blueskyUrl}`);
+        syndicated_to.bluesky = blueskyUrl;
+      } catch (err) {
+        console.error(`Bluesky error: ${err.message}`);
+        errors.push(`${path.relative(ROOT, filePath)} → Bluesky: ${err.message}`);
+      }
+    } else {
+      console.log("Bluesky: already syndicated, skipping.");
     }
 
     if (Object.keys(syndicated_to).length > 0) {
@@ -361,6 +379,7 @@ async function syndicateImages(blueskySession) {
         syndicated_to.mastodon = mastodonUrl;
       } catch (err) {
         console.error(`Mastodon error: ${err.message}`);
+        errors.push(`image ${image.id} → Mastodon: ${err.message}`);
       }
     } else {
       console.log("Mastodon: already syndicated, skipping.");
@@ -379,6 +398,7 @@ async function syndicateImages(blueskySession) {
         syndicated_to.bluesky = blueskyUrl;
       } catch (err) {
         console.error(`Bluesky error: ${err.message}`);
+        errors.push(`image ${image.id} → Bluesky: ${err.message}`);
       }
     } else {
       console.log("Bluesky: already syndicated, skipping.");
@@ -398,6 +418,12 @@ async function main() {
   const blueskySession = { session: null };
   await syndicateMarkdownPosts(blueskySession);
   await syndicateImages(blueskySession);
+
+  if (errors.length > 0) {
+    console.error(`\nSyndication completed with ${errors.length} error(s):`);
+    for (const err of errors) console.error(`  - ${err}`);
+    process.exit(1);
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- `buildCanonicalUrl` now strips the leading `YYYY-MM-DD-` date prefix so syndicated links match Eleventy's `page.fileSlug` (which is what the live URL uses). The mitmproxy post got linked to `/posts/2026-05-13-how-to-mitm-.../` instead of `/posts/how-to-mitm-.../`.
- Per-platform retry: a post is only skipped when **both** Mastodon and Bluesky have succeeded, so a one-sided failure no longer permanently blocks the other platform.
- Surface errors: the script now exits non-zero when any platform errored (after still writing partial successes to front matter), so the GitHub Action fails visibly instead of silently swallowing 401s.
- Cleared the stale `syndicated_to` block on the mitmproxy post so both platforms retry on the next workflow run. The previous Bluesky post (with the wrong URL) was deleted manually.

Note: the underlying reason Mastodon didn't go out is that `MASTODON_ACCESS_TOKEN` is returning 401 — the token needs to be regenerated on fosstodon.org and updated in the repo secrets before the next run will succeed.

## Test plan
- [ ] Regenerate `MASTODON_ACCESS_TOKEN` and update the GitHub secret
- [ ] Merge and let the `syndicate.yml` workflow re-run
- [ ] Confirm both Mastodon and Bluesky posts link to `/posts/how-to-mitm-your-own-phone-for-fun-and-profit/`
- [ ] Confirm `syndicated_to` gets written back with both URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)