### PR TITLE
Add /voicemails/ index and page styling

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -88,6 +88,16 @@ export default async function (eleventyConfig) {
       });
   });
 
+  eleventyConfig.addCollection("voicemails", function (collectionApi) {
+    return collectionApi
+      .getAllSorted()
+      .reverse()
+      .filter((page) => {
+        return page.data.tags?.includes("voicemails") &&
+          page.url !== "/voicemails/";
+      });
+  });
+
   eleventyConfig.setLiquidOptions({
     // Display dates in UTC (so they don't risk being off by one day)
     timezoneOffset: 0,
@@ -117,6 +127,7 @@ export default async function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("favicon.ico");
   eleventyConfig.addPassthroughCopy("CNAME");
   eleventyConfig.addPassthroughCopy("data/workouts/**/*.svg");
+  eleventyConfig.addPassthroughCopy("audio/*.mp3");
   eleventyConfig.addPassthroughCopy({
     "node_modules/web-vitals/dist/web-vitals.js": "assets/web-vitals.js",
   });

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -76,7 +76,7 @@
       <section class="page-header">
         {% if date %}
           <div class="page-eyebrow">
-            <a href="{% if page.url contains '/notes/' and page.url != '/notes/' %}/notes/{% elsif page.url contains '/posts/' and page.url != '/posts/' %}/posts/{% elsif page.url contains '/images/' and page.url != '/images/' %}/images/{% elsif page.url contains '/projects/' and page.url != '/projects/' %}/projects/{% else %}/{% endif %}">← BACK</a>
+            <a href="{% if page.url contains '/notes/' and page.url != '/notes/' %}/notes/{% elsif page.url contains '/posts/' and page.url != '/posts/' %}/posts/{% elsif page.url contains '/voicemails/' and page.url != '/voicemails/' %}/voicemails/{% elsif page.url contains '/images/' and page.url != '/images/' %}/images/{% elsif page.url contains '/projects/' and page.url != '/projects/' %}/projects/{% else %}/{% endif %}">← BACK</a>
             <time datetime="{{ date | date: '%Y-%m-%d' }}">{{ date | isoDate }}</time>
           </div>
         {% endif %}

--- a/css/index.css
+++ b/css/index.css
@@ -617,6 +617,61 @@ main figure figcaption {
   .notes-list .relative { text-align: left; }
 }
 
+/* ── Voicemails ────────────────────────────────────────── */
+.voicemails-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.voicemails-list > li {
+  display: grid;
+  grid-template-columns: 140px 1fr 80px;
+  align-items: center;
+  padding: 20px 0;
+  border-bottom: var(--rule-1);
+  gap: 16px;
+}
+
+.voicemails-list .voicemail-date {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.voicemails-list .voicemail-date:hover { color: var(--accent); }
+
+.voicemails-list .body { margin: 0; }
+.voicemails-list .body p:empty { display: none; }
+
+.voicemails-list .relative {
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-2);
+  text-align: right;
+}
+
+.voicemails-list audio,
+main.reading audio,
+main audio {
+  width: 100%;
+  height: 40px;
+  display: block;
+}
+
+audio::-webkit-media-controls-panel {
+  background: var(--surface);
+}
+
+@media (max-width: 720px) {
+  .voicemails-list > li { grid-template-columns: 1fr; }
+  .voicemails-list .relative { text-align: left; }
+}
+
 /* ── Project grid ──────────────────────────────────────── */
 .project-grid {
   display: grid;

--- a/posts/posts.11tydata.js
+++ b/posts/posts.11tydata.js
@@ -1,0 +1,18 @@
+function isVoicemail(inputPath) {
+  return inputPath?.endsWith("-voicemail.md") ?? false;
+}
+
+export default {
+  eleventyComputed: {
+    permalink: (data) => {
+      if (isVoicemail(data.page.inputPath)) {
+        return `/voicemails/${data.page.fileSlug}/`;
+      }
+      return data.permalink;
+    },
+    tags: (data) => {
+      if (isVoicemail(data.page.inputPath)) return ["voicemails"];
+      return data.tags;
+    },
+  },
+};

--- a/voicemails/index.md
+++ b/voicemails/index.md
@@ -1,0 +1,22 @@
+---
+permalink: /voicemails/index.html
+layout: default
+title: "Voicemails"
+description: "Voicemails left on the koddsson.com hotline."
+noPageHeader: true
+---
+
+<header class="index-hero">
+  <h1>VOICEMAILS.</h1>
+  <span class="meta">N = {{ collections.voicemails.size | prepend: '0' | slice: -2, 2 }} · AUDIO</span>
+</header>
+
+<ul class="voicemails-list">
+  {%- for vm in collections.voicemails -%}
+    <li>
+      <a class="voicemail-date" href="{{ vm.url }}"><time datetime="{{ vm.date | date: '%Y-%m-%dT%H:%M' }}">{{ vm.date | isoDate }}</time></a>
+      <div class="body">{{ vm.content }}</div>
+      <span class="relative">{% relativeTime vm.date %}</span>
+    </li>
+  {%- endfor -%}
+</ul>


### PR DESCRIPTION
## Summary
- Soft-launches a `/voicemails/` listing page for voicemails written into `posts/` by the atlas worker. No nav entry is added, so it's discoverable only by URL.
- Voicemail posts (files matching `*-voicemail.md`) are rerouted via `eleventyComputed` to `/voicemails/<slug>/` and re-tagged `voicemails`, removing them from the regular posts collection.
- Adds an `audio/*.mp3` passthrough so the MP3s atlas commits actually ship in `_site/`.

## Test plan
- [ ] `npm run build` succeeds and produces `_site/posts/index.html` (regular posts listing) without the voicemail, `_site/voicemails/index.html`, and `_site/voicemails/2026-05-13T1329-voicemail/index.html`.
- [ ] `_site/audio/2026-05-13T1329-voicemail.mp3` is copied through.
- [ ] On the live site, `/voicemails/` shows the voicemail with a working audio player; individual voicemail page has a BACK link to `/voicemails/`.
- [ ] Existing posts at `/posts/<slug>/` and `/posts/` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)